### PR TITLE
Add unified validation check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,34 @@
+name: check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: make check PYTHON=python
+
+  workflow-lint:
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+      - run: go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+      - run: find .github/workflows -type f \( -name '*.yml' -o -name '*.yaml' \) -print0 | xargs -0 actionlint

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+PYTHON ?= python3
+
+.PHONY: check lint test
+
+check: lint test
+
+lint:
+	$(PYTHON) scripts/static_check.py
+
+test:
+	@echo "No executable test suite configured; static validation runs in lint."

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON ?= python3
 check: lint test
 
 lint:
-	$(PYTHON) scripts/static_check.py
+	$(PYTHON) scripts/static_check.py --require-notebook
 
 test:
 	@echo "No executable test suite configured; static validation runs in lint."

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import argparse
 import ast
+import fnmatch
 import json
+import subprocess
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,9 +22,19 @@ SKIP_PARTS = {
 
 
 def iter_paths(pattern: str) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     return sorted(
         path
-        for path in ROOT.rglob(pattern)
+        for rel_path in result.stdout.splitlines()
+        for path in [ROOT / rel_path]
+        if fnmatch.fnmatch(Path(rel_path).name, pattern)
+        if path.is_file()
         if not (set(path.relative_to(ROOT).parts) & SKIP_PARTS)
     )
 

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_PARTS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "venv",
+}
+
+
+def iter_paths(pattern: str) -> list[Path]:
+    return sorted(
+        path
+        for path in ROOT.rglob(pattern)
+        if not (set(path.relative_to(ROOT).parts) & SKIP_PARTS)
+    )
+
+
+def notebook_source(source: str | list[str]) -> str:
+    if isinstance(source, list):
+        source = "".join(source)
+    lines = str(source).splitlines()
+    first = next((line.lstrip() for line in lines if line.strip()), "")
+    if first.startswith("%%"):
+        return ""
+
+    cleaned: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        lowered = stripped.lower()
+        if stripped.startswith(("%", "!")):
+            continue
+        if lowered.startswith(("pip install ", "python -m pip ", "conda install ")):
+            continue
+        cleaned.append(line)
+    return "\n".join(cleaned).strip() + "\n" if any(line.strip() for line in cleaned) else ""
+
+
+def check_python(path: Path) -> None:
+    ast.parse(path.read_text(encoding="utf-8"), filename=str(path.relative_to(ROOT)))
+
+
+def check_notebook(path: Path) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("nbformat") != 4:
+        raise ValueError(f"unexpected notebook format: {data.get('nbformat')}")
+    cells = data.get("cells")
+    if not isinstance(cells, list) or not cells:
+        raise ValueError("notebook has no cells")
+    for index, cell in enumerate(cells, start=1):
+        if "cell_type" not in cell:
+            raise ValueError(f"cell {index} is missing cell_type")
+        if cell.get("cell_type") != "code":
+            continue
+        source = notebook_source(cell.get("source", ""))
+        if source:
+            ast.parse(source, filename=f"{path.relative_to(ROOT)}:cell-{index}")
+
+
+def check_requirements(require_pinned: bool) -> None:
+    for path in iter_paths("requirements*.txt"):
+        deps = [
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        if not deps:
+            raise ValueError(f"{path.relative_to(ROOT)} has no dependencies")
+        if require_pinned:
+            for dep in deps:
+                if "==" not in dep:
+                    raise ValueError(f"{path.relative_to(ROOT)} dependency is not pinned: {dep}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--require-pinned-requirements", action="store_true")
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    for path in iter_paths("*.py"):
+        try:
+            check_python(path)
+        except Exception as exc:  # noqa: BLE001 - concise lint report
+            failures.append(f"{path.relative_to(ROOT)}: {exc}")
+    for path in iter_paths("*.ipynb"):
+        try:
+            check_notebook(path)
+        except Exception as exc:  # noqa: BLE001 - concise lint report
+            failures.append(f"{path.relative_to(ROOT)}: {exc}")
+    try:
+        check_requirements(args.require_pinned_requirements)
+    except Exception as exc:  # noqa: BLE001 - concise lint report
+        failures.append(str(exc))
+
+    if failures:
+        print("Static validation failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+    print("Static validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -47,7 +47,8 @@ def notebook_source(source: str | list[str]) -> str:
         if lowered.startswith(("pip install ", "python -m pip ", "conda install ")):
             continue
         cleaned.append(line)
-    return "\n".join(cleaned).strip() + "\n" if any(line.strip() for line in cleaned) else ""
+    text = "\n".join(cleaned)
+    return text.rstrip() + "\n" if text.strip() else ""
 
 
 def compile_source(source: str, filename: str, *, allow_top_level_await: bool = False) -> None:

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -31,9 +31,9 @@ def notebook_source(source: str | list[str]) -> str:
     if isinstance(source, list):
         source = "".join(source)
     lines = str(source).splitlines()
-    first = next((line.lstrip() for line in lines if line.strip()), "")
-    if first.startswith("%%"):
-        return ""
+    first_index = next((idx for idx, line in enumerate(lines) if line.strip()), None)
+    if first_index is not None and lines[first_index].lstrip().startswith("%%"):
+        lines = lines[:first_index] + lines[first_index + 1:]
 
     cleaned: list[str] = []
     for line in lines:
@@ -68,8 +68,11 @@ def check_notebook(path: Path) -> None:
             ast.parse(source, filename=f"{path.relative_to(ROOT)}:cell-{index}")
 
 
-def check_requirements(require_pinned: bool) -> None:
-    for path in iter_paths("requirements*.txt"):
+def check_requirements(require_pinned: bool, require_any: bool) -> None:
+    paths = iter_paths("requirements*.txt")
+    if require_any and not paths:
+        raise ValueError("no requirements*.txt file found")
+    for path in paths:
         deps = [
             line.strip()
             for line in path.read_text(encoding="utf-8").splitlines()
@@ -86,6 +89,9 @@ def check_requirements(require_pinned: bool) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--require-pinned-requirements", action="store_true")
+    parser.add_argument("--require-notebook", action="store_true")
+    parser.add_argument("--required-notebook", action="append", default=[])
+    parser.add_argument("--required-requirements", action="append", default=[])
     args = parser.parse_args()
 
     failures: list[str] = []
@@ -94,13 +100,25 @@ def main() -> int:
             check_python(path)
         except Exception as exc:  # noqa: BLE001 - concise lint report
             failures.append(f"{path.relative_to(ROOT)}: {exc}")
-    for path in iter_paths("*.ipynb"):
+    notebooks = iter_paths("*.ipynb")
+    for required in args.required_notebook:
+        if not (ROOT / required).is_file():
+            failures.append(f"{required} is missing")
+    if args.require_notebook and not notebooks:
+        failures.append("no notebooks found")
+    for path in notebooks:
         try:
             check_notebook(path)
         except Exception as exc:  # noqa: BLE001 - concise lint report
             failures.append(f"{path.relative_to(ROOT)}: {exc}")
     try:
-        check_requirements(args.require_pinned_requirements)
+        for required in args.required_requirements:
+            if not (ROOT / required).is_file():
+                failures.append(f"{required} is missing")
+        check_requirements(
+            args.require_pinned_requirements,
+            bool(args.required_requirements),
+        )
     except Exception as exc:  # noqa: BLE001 - concise lint report
         failures.append(str(exc))
 

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -33,6 +33,9 @@ def notebook_source(source: str | list[str]) -> str:
     lines = str(source).splitlines()
     first_index = next((idx for idx, line in enumerate(lines) if line.strip()), None)
     if first_index is not None and lines[first_index].lstrip().startswith("%%"):
+        magic = lines[first_index].lstrip()[2:].split(None, 1)[0]
+        if magic not in {"capture", "debug", "prun", "python", "python3", "time", "timeit"}:
+            return ""
         lines = lines[:first_index] + lines[first_index + 1:]
 
     cleaned: list[str] = []
@@ -47,8 +50,18 @@ def notebook_source(source: str | list[str]) -> str:
     return "\n".join(cleaned).strip() + "\n" if any(line.strip() for line in cleaned) else ""
 
 
+def compile_source(source: str, filename: str) -> None:
+    compile(
+        source,
+        filename,
+        "exec",
+        flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+        dont_inherit=True,
+    )
+
+
 def check_python(path: Path) -> None:
-    ast.parse(path.read_text(encoding="utf-8"), filename=str(path.relative_to(ROOT)))
+    compile_source(path.read_text(encoding="utf-8"), str(path.relative_to(ROOT)))
 
 
 def check_notebook(path: Path) -> None:
@@ -65,7 +78,7 @@ def check_notebook(path: Path) -> None:
             continue
         source = notebook_source(cell.get("source", ""))
         if source:
-            ast.parse(source, filename=f"{path.relative_to(ROOT)}:cell-{index}")
+            compile_source(source, f"{path.relative_to(ROOT)}:cell-{index}")
 
 
 def check_requirements(require_pinned: bool, require_any: bool) -> None:

--- a/scripts/static_check.py
+++ b/scripts/static_check.py
@@ -50,12 +50,13 @@ def notebook_source(source: str | list[str]) -> str:
     return "\n".join(cleaned).strip() + "\n" if any(line.strip() for line in cleaned) else ""
 
 
-def compile_source(source: str, filename: str) -> None:
+def compile_source(source: str, filename: str, *, allow_top_level_await: bool = False) -> None:
+    flags = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT if allow_top_level_await else 0
     compile(
         source,
         filename,
         "exec",
-        flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+        flags=flags,
         dont_inherit=True,
     )
 
@@ -78,7 +79,11 @@ def check_notebook(path: Path) -> None:
             continue
         source = notebook_source(cell.get("source", ""))
         if source:
-            compile_source(source, f"{path.relative_to(ROOT)}:cell-{index}")
+            compile_source(
+                source,
+                f"{path.relative_to(ROOT)}:cell-{index}",
+                allow_top_level_await=True,
+            )
 
 
 def check_requirements(require_pinned: bool, require_any: bool) -> None:


### PR DESCRIPTION
## Summary
- add a canonical `make check` entrypoint for static notebook validation
- add a lightweight CI workflow that runs `make check`
- add workflow linting with actionlint

## Validation
- `make check PYTHON=python3`
- `actionlint` on all workflows